### PR TITLE
Let Granian choose event loop to use

### DIFF
--- a/microbootstrap/granian_server.py
+++ b/microbootstrap/granian_server.py
@@ -32,7 +32,6 @@ def create_granian_server(
         address=settings.server_host,
         port=settings.server_port,
         interface=Interfaces.ASGI,
-        loop=Loops.uvloop,
         workers=settings.server_workers_count,
         log_level=GRANIAN_LOG_LEVELS_MAP[getattr(settings, "logging_log_level", logging.INFO)],
         reload=settings.server_reload,


### PR DESCRIPTION
As @gi0baro [pointed out](https://github.com/community-of-python/microbootstrap/issues/3#issuecomment-2269494352):

>  if you don't specify that option Granian will use uvloop on supported platforms and asyncio on all the others by default. You just need to drop that line.