### PR TITLE
Disable offline docs by default

### DIFF
--- a/microbootstrap/instruments/swagger_instrument.py
+++ b/microbootstrap/instruments/swagger_instrument.py
@@ -14,7 +14,7 @@ class SwaggerConfig(BaseInstrumentConfig):
     service_static_path: str = "/static"
 
     swagger_path: str = "/docs"
-    swagger_offline_docs: bool = True
+    swagger_offline_docs: bool = False
     swagger_extra_params: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
 
 

--- a/tests/instruments/test_swagger.py
+++ b/tests/instruments/test_swagger.py
@@ -39,7 +39,6 @@ def test_swagger_teardown(
 
 
 def test_litestar_swagger_bootstrap_online_docs(minimal_swagger_config: SwaggerConfig) -> None:
-    minimal_swagger_config.swagger_offline_docs = False
     swagger_instrument: typing.Final = LitestarSwaggerInstrument(minimal_swagger_config)
 
     swagger_instrument.bootstrap()
@@ -53,6 +52,7 @@ def test_litestar_swagger_bootstrap_online_docs(minimal_swagger_config: SwaggerC
 
 
 def test_litestar_swagger_bootstrap_offline_docs(minimal_swagger_config: SwaggerConfig) -> None:
+    minimal_swagger_config.swagger_offline_docs = True
     swagger_instrument: typing.Final = LitestarSwaggerInstrument(minimal_swagger_config)
 
     swagger_instrument.bootstrap()
@@ -72,7 +72,6 @@ async def test_litestar_swagger_bootstrap_working_online_docs(
     minimal_swagger_config: SwaggerConfig,
 ) -> None:
     minimal_swagger_config.swagger_path = "/my-docs-path"
-    minimal_swagger_config.swagger_offline_docs = False
     swagger_instrument: typing.Final = LitestarSwaggerInstrument(minimal_swagger_config)
 
     swagger_instrument.bootstrap()
@@ -89,6 +88,7 @@ async def test_litestar_swagger_bootstrap_working_offline_docs(
     minimal_swagger_config: SwaggerConfig,
 ) -> None:
     minimal_swagger_config.service_static_path = "/my-static-path"
+    minimal_swagger_config.swagger_offline_docs = True
     swagger_instrument: typing.Final = LitestarSwaggerInstrument(minimal_swagger_config)
 
     swagger_instrument.bootstrap()
@@ -116,7 +116,6 @@ async def test_fastapi_swagger_bootstrap_working_online_docs(
     minimal_swagger_config: SwaggerConfig,
 ) -> None:
     minimal_swagger_config.swagger_path = "/my-docs-path"
-    minimal_swagger_config.swagger_offline_docs = False
     swagger_instrument: typing.Final = FastApiSwaggerInstrument(minimal_swagger_config)
 
     swagger_instrument.bootstrap()
@@ -133,6 +132,7 @@ async def test_fastapi_swagger_bootstrap_working_offline_docs(
     minimal_swagger_config: SwaggerConfig,
 ) -> None:
     minimal_swagger_config.service_static_path = "/my-static-path"
+    minimal_swagger_config.swagger_offline_docs = True
     swagger_instrument: typing.Final = FastApiSwaggerInstrument(minimal_swagger_config)
     fastapi_application = fastapi.FastAPI(
         **swagger_instrument.bootstrap_before(),


### PR DESCRIPTION
Currently we do not use offline docs by default. This will ease the migration because we wouldn't need to open access to `/static` route for micro-services.

Sorry for the friction.