### PR TITLE
Actually disable debug by default

### DIFF
--- a/microbootstrap/instruments/logging_instrument.py
+++ b/microbootstrap/instruments/logging_instrument.py
@@ -116,7 +116,7 @@ class MemoryLoggerFactory(structlog.stdlib.LoggerFactory):
 
 
 class LoggingConfig(BaseInstrumentConfig):
-    service_debug: bool = True
+    service_debug: bool = False
 
     logging_log_level: int = logging.INFO
     logging_flush_level: int = logging.ERROR


### PR DESCRIPTION
`BaseServiceSettings` has to go first to make sure the default settings defined there are not overwritten.