### PR TITLE
Exclude `/health` route from OpenAPI schema by default, and allow to configure it

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ class YourSettings(BaseServiceSettings):
 
     health_checks_enabled: bool = True
     health_checks_path: str = "/health/"
+    health_checks_include_in_schema: bool = False
 ```
 
 Parameter descriptions:
@@ -430,6 +431,7 @@ Parameter descriptions:
 - `service_version` - Will be displayed in health check response.
 - `health_checks_enabled` - Must be True to enable health checks.
 - `health_checks_path` - Path for health check handler.
+- `health_checks_include_in_schema` - Must be True to include `health_checks_path` (`/health/`) in OpenAPI schema.
 
 ## Configuration
 
@@ -558,7 +560,7 @@ application: litestar.Litestar = (
 ## Advanced
 
 If you miss some instrument, you can add your own.
-Essentialy, `Instrument` is just a class with some abstractmethods.
+Essentially, `Instrument` is just a class with some abstractmethods.
 Every instrument uses some config, so that's first thing, you have to define.
 
 ```python

--- a/microbootstrap/bootstrappers/fastapi.py
+++ b/microbootstrap/bootstrappers/fastapi.py
@@ -122,6 +122,10 @@ class FastApiPrometheusInstrument(PrometheusInstrument[FastApiPrometheusConfig])
 class FastApiHealthChecksInstrument(HealthChecksInstrument):
     def bootstrap_after(self, application: fastapi.FastAPI) -> fastapi.FastAPI:
         application.include_router(
-            build_fastapi_health_check_router(self.health_check, self.instrument_config.health_checks_path),
+            build_fastapi_health_check_router(
+                health_check=self.health_check,
+                health_check_endpoint=self.instrument_config.health_checks_path,
+                include_in_schema=self.instrument_config.health_checks_include_in_schema,
+            ),
         )
         return application

--- a/microbootstrap/bootstrappers/litestar.py
+++ b/microbootstrap/bootstrappers/litestar.py
@@ -147,8 +147,9 @@ class LitestarHealthChecksInstrument(HealthChecksInstrument):
         return {
             "route_handlers": [
                 build_litestar_health_check_router(
-                    self.health_check,
-                    self.instrument_config.health_checks_path,
+                    health_check=self.health_check,
+                    health_check_endpoint=self.instrument_config.health_checks_path,
+                    include_in_schema=self.instrument_config.health_checks_include_in_schema,
                 ),
             ],
         }

--- a/microbootstrap/instruments/health_checks_instrument.py
+++ b/microbootstrap/instruments/health_checks_instrument.py
@@ -11,6 +11,7 @@ class HealthChecksConfig(BaseInstrumentConfig):
 
     health_checks_enabled: bool = True
     health_checks_path: str = "/health/"
+    health_checks_include_in_schema: bool = False
 
 
 class HealthChecksInstrument(Instrument[HealthChecksConfig]):

--- a/poetry.lock
+++ b/poetry.lock
@@ -921,13 +921,13 @@ files = [
 
 [[package]]
 name = "health-checks"
-version = "1.0.0"
+version = "1.1.0"
 description = "Library for health checks"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "health_checks-1.0.0-py3-none-any.whl", hash = "sha256:be2258f4d8f64a85ae47afbd28180f48a7555ebe93eb7854d86c5b7235ea3217"},
-    {file = "health_checks-1.0.0.tar.gz", hash = "sha256:bea8fbfc42af8a6ec39f68c9f9397049c4594d1f1879e91e1d627e219d31124e"},
+    {file = "health_checks-1.1.0-py3-none-any.whl", hash = "sha256:c5e9a91b3da3a75290cf57da2465ebd40b06d08654febc69d1d3f5341fecff2f"},
+    {file = "health_checks-1.1.0.tar.gz", hash = "sha256:c0f9457a7cdb2b43f7d67c85a935a3a5d2766b1b6b9b58807421b3caa11368eb"},
 ]
 
 [package.dependencies]
@@ -3042,4 +3042,4 @@ litestar = ["litestar", "litestar-offline-docs", "prometheus-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "9a68b146e222e62afda214abcb0b9bdca20de5a6bb1c2f2617718af9f7217a7a"
+content-hash = "86763ee469dbab64f82789c9a9911989d2392bff9f245f80de2c59b28489d8af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ fastapi = { version = "^0.111.0", optional = true }
 prometheus-fastapi-instrumentator = { version = "^6.1.0", optional = true }
 opentelemetry-instrumentation-fastapi = { version = "^0.46b0", optional = true }
 fastapi-offline-docs = { version = "^1.0.1", optional = true }
-health-checks = "^1.0.0"
+health-checks = "^1.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"


### PR DESCRIPTION
Closes #34 