### PR TITLE
Make sure `Any` types are not converted to dict if applicable when merging Pydantic configs

### DIFF
--- a/microbootstrap/helpers.py
+++ b/microbootstrap/helpers.py
@@ -36,11 +36,13 @@ def merge_pydantic_configs(
     config_to_merge: PydanticConfigT,
     config_with_changes: PydanticConfigT,
 ) -> PydanticConfigT:
+    initial_fields: typing.Final = dict(config_to_merge)
     changed_fields: typing.Final = {
         one_field_name: getattr(config_with_changes, one_field_name)
         for one_field_name in config_with_changes.model_fields_set
     }
-    return config_to_merge.model_copy(update=changed_fields)
+    merged_fields: typing.Final = merge_dict_configs(initial_fields, changed_fields)
+    return config_to_merge.model_copy(update=merged_fields)
 
 
 def merge_dataclasses_configs(

--- a/microbootstrap/helpers.py
+++ b/microbootstrap/helpers.py
@@ -36,12 +36,11 @@ def merge_pydantic_configs(
     config_to_merge: PydanticConfigT,
     config_with_changes: PydanticConfigT,
 ) -> PydanticConfigT:
-    config_class: typing.Final = config_to_merge.__class__
-    resulting_dict_config: typing.Final = merge_dict_configs(
-        config_to_merge.model_dump(exclude_defaults=True, exclude_unset=True),
-        config_with_changes.model_dump(exclude_defaults=True, exclude_unset=True),
-    )
-    return config_class(**resulting_dict_config)
+    changed_fields: typing.Final = {
+        one_field_name: getattr(config_with_changes, one_field_name)
+        for one_field_name in config_with_changes.model_fields_set
+    }
+    return config_to_merge.model_copy(update=changed_fields)
 
 
 def merge_dataclasses_configs(

--- a/tests/instruments/test_swagger.py
+++ b/tests/instruments/test_swagger.py
@@ -66,16 +66,18 @@ def test_litestar_swagger_bootstrap_with_overridden_render_plugins(minimal_swagg
 
 
 def test_litestar_swagger_bootstrap_extra_params_have_correct_types(minimal_swagger_config: SwaggerConfig) -> None:
-    minimal_swagger_config.swagger_extra_params["components"] = litestar_openapi.Components(
+    swagger_instrument: typing.Final = LitestarSwaggerInstrument(minimal_swagger_config)
+    new_components: typing.Final = litestar_openapi.Components(
         security_schemes={"Bearer": litestar_openapi.SecurityScheme(type="http", scheme="Bearer")}
     )
-
-    swagger_instrument: typing.Final = LitestarSwaggerInstrument(minimal_swagger_config)
+    swagger_instrument.configure_instrument(
+        minimal_swagger_config.model_copy(update={"swagger_extra_params": {"components": new_components}})
+    )
     bootstrap_result: typing.Final = swagger_instrument.bootstrap_before()
 
     assert "openapi_config" in bootstrap_result
     assert isinstance(bootstrap_result["openapi_config"], openapi.OpenAPIConfig)
-    assert isinstance(bootstrap_result["openapi_config"].components, litestar_openapi.Components)
+    assert type(bootstrap_result["openapi_config"].components) is litestar_openapi.Components
 
 
 def test_litestar_swagger_bootstrap_offline_docs(minimal_swagger_config: SwaggerConfig) -> None:

--- a/tests/instruments/test_swagger.py
+++ b/tests/instruments/test_swagger.py
@@ -4,6 +4,7 @@ import fastapi
 import litestar
 from httpx import AsyncClient
 from litestar import openapi, status_codes
+from litestar.openapi import spec as litestar_openapi
 from litestar.openapi.plugins import ScalarRenderPlugin
 from litestar.static_files import StaticFilesConfig
 from litestar.testing import AsyncTestClient
@@ -52,7 +53,7 @@ def test_litestar_swagger_bootstrap_online_docs(minimal_swagger_config: SwaggerC
     assert "static_files_config" not in bootstrap_result
 
 
-def test_litestar_swagger_bootstrap_with_overriden_render_plugins(minimal_swagger_config: SwaggerConfig) -> None:
+def test_litestar_swagger_bootstrap_with_overridden_render_plugins(minimal_swagger_config: SwaggerConfig) -> None:
     new_render_plugins: typing.Final = [ScalarRenderPlugin()]
     minimal_swagger_config.swagger_extra_params["render_plugins"] = new_render_plugins
 
@@ -62,6 +63,19 @@ def test_litestar_swagger_bootstrap_with_overriden_render_plugins(minimal_swagge
     assert "openapi_config" in bootstrap_result
     assert isinstance(bootstrap_result["openapi_config"], openapi.OpenAPIConfig)
     assert bootstrap_result["openapi_config"].render_plugins is new_render_plugins
+
+
+def test_litestar_swagger_bootstrap_extra_params_have_correct_types(minimal_swagger_config: SwaggerConfig) -> None:
+    minimal_swagger_config.swagger_extra_params["components"] = litestar_openapi.Components(
+        security_schemes={"Bearer": litestar_openapi.SecurityScheme(type="http", scheme="Bearer")}
+    )
+
+    swagger_instrument: typing.Final = LitestarSwaggerInstrument(minimal_swagger_config)
+    bootstrap_result: typing.Final = swagger_instrument.bootstrap_before()
+
+    assert "openapi_config" in bootstrap_result
+    assert isinstance(bootstrap_result["openapi_config"], openapi.OpenAPIConfig)
+    assert isinstance(bootstrap_result["openapi_config"].components, litestar_openapi.Components)
 
 
 def test_litestar_swagger_bootstrap_offline_docs(minimal_swagger_config: SwaggerConfig) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -49,6 +49,11 @@ class PydanticConfig(pydantic.BaseModel):
     dict_field: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
 
 
+@dataclasses.dataclass
+class SomeInnerDataclass:
+    string_field: str
+
+
 @pytest.mark.parametrize(
     ("first_model", "second_model", "result"),
     [
@@ -74,6 +79,19 @@ class PydanticConfig(pydantic.BaseModel):
                 string_field="value2",
                 array_field=[1, 2, 1, 3],
                 dict_field={"value1": 1, "value2": 2, "value3": 4},
+            ),
+        ),
+        (
+            PydanticConfig(string_field="value1", array_field=[1, 2], dict_field={"value1": 1, "value3": 3}),
+            PydanticConfig(
+                string_field="value2",
+                array_field=[SomeInnerDataclass(string_field="hi")],
+                dict_field={"value1": 1, "value2": 2, "value3": SomeInnerDataclass(string_field="there")},
+            ),
+            PydanticConfig(
+                string_field="value2",
+                array_field=[1, 2, SomeInnerDataclass(string_field="hi")],
+                dict_field={"value1": 1, "value2": 2, "value3": SomeInnerDataclass(string_field="there")},
             ),
         ),
     ],

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -50,7 +50,7 @@ class PydanticConfig(pydantic.BaseModel):
 
 
 @dataclasses.dataclass
-class SomeInnerDataclass:
+class InnerDataclass:
     string_field: str
 
 
@@ -85,13 +85,13 @@ class SomeInnerDataclass:
             PydanticConfig(string_field="value1", array_field=[1, 2], dict_field={"value1": 1, "value3": 3}),
             PydanticConfig(
                 string_field="value2",
-                array_field=[SomeInnerDataclass(string_field="hi")],
-                dict_field={"value1": 1, "value2": 2, "value3": SomeInnerDataclass(string_field="there")},
+                array_field=[InnerDataclass(string_field="hi")],
+                dict_field={"value1": 1, "value2": 2, "value3": InnerDataclass(string_field="there")},
             ),
             PydanticConfig(
                 string_field="value2",
-                array_field=[1, 2, SomeInnerDataclass(string_field="hi")],
-                dict_field={"value1": 1, "value2": 2, "value3": SomeInnerDataclass(string_field="there")},
+                array_field=[1, 2, InnerDataclass(string_field="hi")],
+                dict_field={"value1": 1, "value2": 2, "value3": InnerDataclass(string_field="there")},
             ),
         ),
     ],


### PR DESCRIPTION
Overriding `microbootstrap.SwaggerConfig.swagger_extra_params` fails. It recursively converts all dataclasses into dicts. Same heuristic applies to any other instrument config that allows `Any` in container types.

```python
import rich
from litestar.openapi.spec import Components, SecurityScheme

import microbootstrap
from microbootstrap.bootstrappers.litestar import LitestarBootstrapper


swagger_config = microbootstrap.SwaggerConfig(
    swagger_extra_params={
        "components": Components(security_schemes={"Bearer": SecurityScheme(type="http", scheme="Bearer")})
    }
)
application = LitestarBootstrapper(microbootstrap.LitestarSettings()).configure_instrument(swagger_config).bootstrap()

assert application.openapi_config
rich.print(application.openapi_config.components)
```

Before the fix and after:

<img width="1049" alt="Screenshot 2024-10-24 at 11 22 58" src="https://github.com/user-attachments/assets/e2b22295-7604-425c-b661-9bbac1757a71">
