### PR TITLE
Some changes for fastapi bootstrapper

### DIFF
--- a/microbootstrap/bootstrappers/base.py
+++ b/microbootstrap/bootstrappers/base.py
@@ -85,7 +85,7 @@ class ApplicationBootstrapper(abc.ABC, typing.Generic[SettingsT, ApplicationT, D
             dataclass_to_dict_no_defaults(self.application_config),
         )
         application = self.application_type(
-            **merge_dict_configs(resulting_application_config, self.bootstrap_before()),
+            **merge_dict_configs(self.bootstrap_before(), resulting_application_config),
         )
 
         for instrument in self.instrument_box.instruments:

--- a/microbootstrap/bootstrappers/base.py
+++ b/microbootstrap/bootstrappers/base.py
@@ -85,7 +85,7 @@ class ApplicationBootstrapper(abc.ABC, typing.Generic[SettingsT, ApplicationT, D
             dataclass_to_dict_no_defaults(self.application_config),
         )
         application = self.application_type(
-            **merge_dict_configs(self.bootstrap_before(), resulting_application_config),
+            **merge_dict_configs(resulting_application_config, self.bootstrap_before()),
         )
 
         for instrument in self.instrument_box.instruments:

--- a/microbootstrap/bootstrappers/fastapi.py
+++ b/microbootstrap/bootstrappers/fastapi.py
@@ -6,7 +6,7 @@ from fastapi_offline_docs import enable_offline_docs
 from health_checks.fastapi_healthcheck import build_fastapi_health_check_router
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
-from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 from microbootstrap.bootstrappers.base import ApplicationBootstrapper
 from microbootstrap.config.fastapi import FastApiConfig
@@ -40,13 +40,9 @@ class FastApiBootstrapper(
 
 @FastApiBootstrapper.use_instrument()
 class FastApiSentryInstrument(SentryInstrument):
-    def bootstrap(self) -> None:
-        for sentry_integration in self.instrument_config.sentry_integrations:
-            if isinstance(sentry_integration, FastApiIntegration):
-                break
-        else:
-            self.instrument_config.sentry_integrations.append(FastApiIntegration())
-        super().bootstrap()
+    def bootstrap_after(self, application: ApplicationT) -> ApplicationT:
+        application.add_middleware(SentryAsgiMiddleware)
+        return application
 
 
 @FastApiBootstrapper.use_instrument()

--- a/microbootstrap/instruments/base.py
+++ b/microbootstrap/instruments/base.py
@@ -40,8 +40,7 @@ class Instrument(abc.ABC, typing.Generic[InstrumentConfigT]):
         )
 
     @abc.abstractmethod
-    def is_ready(self) -> bool:
-        raise NotImplementedError
+    def is_ready(self) -> bool: ...
 
     @classmethod
     @abc.abstractmethod

--- a/tests/instruments/test_sentry.py
+++ b/tests/instruments/test_sentry.py
@@ -66,6 +66,8 @@ def test_litestar_sentry_bootstrap_catch_exception(
 def test_fastapi_sentry_bootstrap(minimal_sentry_config: SentryConfig) -> None:
     sentry_instrument: typing.Final = FastApiSentryInstrument(minimal_sentry_config)
     sentry_instrument.bootstrap()
+    app = fastapi.FastAPI()
+    assert sentry_instrument.bootstrap_after(app) is app
     assert sentry_instrument.bootstrap_before() == {}
 
 


### PR DESCRIPTION
# What's changed

1. replace sentry FastApiIntegration with SentryAsgiMiddleware, because FastApiIntegration works really bad