### PR TITLE
Use lifespan instead of on_shutdown and on_startup for fastapi

### DIFF
--- a/microbootstrap/bootstrappers/fastapi.py
+++ b/microbootstrap/bootstrappers/fastapi.py
@@ -46,11 +46,11 @@ class FastApiBootstrapper(
 
     def _choose_lifespan_manager(
         self,
-    ) -> typing.Callable[[fastapi.FastAPI], typing.AsyncIterator[dict[str, typing.Any]]]:
+    ) -> typing.Callable[[fastapi.FastAPI], typing.AsyncContextManager[dict[str, typing.Any]]]:
         if self.application_config.lifespan:
-            return self._wrapped_lifespan_manager  # type: ignore[return-value]
+            return self._wrapped_lifespan_manager
 
-        return self._lifespan_manager  # type: ignore[return-value]
+        return self._lifespan_manager
 
     def bootstrap_before(self) -> dict[str, typing.Any]:
         return {

--- a/tests/bootstrappers/test_fastapi.py
+++ b/tests/bootstrappers/test_fastapi.py
@@ -49,14 +49,9 @@ def test_fastapi_configure_application() -> None:
     assert application.title == test_title
 
 
-def test_fastapi_configure_application_add_startup_event(magic_mock: MagicMock) -> None:
-    def test_startup() -> None:
-        magic_mock()
-
+def test_fastapi_configure_application_lifespan(magic_mock: MagicMock) -> None:
     application: typing.Final = (
-        FastApiBootstrapper(FastApiSettings())
-        .configure_application(FastApiConfig(on_startup=[test_startup]))
-        .bootstrap()
+        FastApiBootstrapper(FastApiSettings()).configure_application(FastApiConfig(lifespan=magic_mock)).bootstrap()
     )
 
     with TestClient(app=application):


### PR DESCRIPTION
@vrslev Applied your idea about wrapping lifespan