### PR TITLE
remove litestar import in common section

### DIFF
--- a/microbootstrap/bootstrappers/litestar.py
+++ b/microbootstrap/bootstrappers/litestar.py
@@ -92,7 +92,7 @@ class LitestarCorsInstrument(CorsInstrument):
         return {
             "cors_config": LitestarCorsConfig(
                 allow_origins=self.instrument_config.cors_allowed_origins,
-                allow_methods=self.instrument_config.cors_allowed_methods,
+                allow_methods=self.instrument_config.cors_allowed_methods,  # type: ignore[arg-type]
                 allow_headers=self.instrument_config.cors_allowed_headers,
                 allow_credentials=self.instrument_config.cors_allowed_credentials,
                 allow_origin_regex=self.instrument_config.cors_allowed_origin_regex,

--- a/microbootstrap/instruments/cors_instrument.py
+++ b/microbootstrap/instruments/cors_instrument.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
-import typing
 
 import pydantic
-from litestar.types import Method  # noqa: TC002
 
 from microbootstrap.instruments.base import BaseInstrumentConfig, Instrument
 
 
 class CorsConfig(BaseInstrumentConfig):
     cors_allowed_origins: list[str] = pydantic.Field(default_factory=list)
-    cors_allowed_methods: list[typing.Literal["*"] | Method] = pydantic.Field(default_factory=list)
+    cors_allowed_methods: list[str] = pydantic.Field(default_factory=list)
     cors_allowed_headers: list[str] = pydantic.Field(default_factory=list)
     cors_exposed_headers: list[str] = pydantic.Field(default_factory=list)
     cors_allowed_credentials: bool = False


### PR DESCRIPTION
returned back type ignore because of import error. It's the easiest way to fix

```
    from litestar.types import Method  # noqa: TC002
E   ModuleNotFoundError: No module named 'litestar'

```