### PR TITLE
allow service name redefine for OTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ class YourSettings(BaseServiceSettings):
     service_name: str
     service_version: str
 
+    opentelemetry_service_name: str | None = None
     opentelemetry_container_name: str | None = None
     opentelemetry_endpoint: str | None = None
     opentelemetry_namespace: str | None = None
@@ -315,6 +316,7 @@ Parameters description:
 
 - `service_name` - will be passed to the `Resource`.
 - `service_version` - will be passed to the `Resource`.
+- `opentelemetry_service_name` - if provided, will be passed to the `Resource` instead of `service_name`.
 - `opentelemetry_endpoint` - will be passed to `OTLPSpanExporter` as endpoint.
 - `opentelemetry_namespace` - will be passed to the `Resource`.
 - `opentelemetry_insecure` - is opentelemetry connection secure.

--- a/microbootstrap/instruments/opentelemetry_instrument.py
+++ b/microbootstrap/instruments/opentelemetry_instrument.py
@@ -22,6 +22,7 @@ class OpentelemetryConfig(BaseInstrumentConfig):
     service_name: str = "micro-service"
     service_version: str = "1.0.0"
 
+    opentelemetry_service_name: str | None = None
     opentelemetry_container_name: str | None = None
     opentelemetry_endpoint: str | None = None
     opentelemetry_namespace: str | None = None
@@ -52,7 +53,8 @@ class OpentelemetryInstrument(Instrument[OpentelemetryConfig]):
     def bootstrap(self) -> None:
         resource: typing.Final = resources.Resource.create(
             attributes={
-                resources.SERVICE_NAME: self.instrument_config.service_name,
+                resources.SERVICE_NAME: self.instrument_config.opentelemetry_service_name
+                or self.instrument_config.service_name,
                 resources.TELEMETRY_SDK_LANGUAGE: "python",
                 resources.SERVICE_NAMESPACE: self.instrument_config.opentelemetry_namespace,  # type: ignore[dict-item]
                 resources.SERVICE_VERSION: self.instrument_config.service_version,


### PR DESCRIPTION
We need this, because we have service name with some prefix, specific for opentelemetry