### PR TITLE
allow extra keys to fix bug with initiating app settings with keys passed

### DIFF
--- a/microbootstrap/settings.py
+++ b/microbootstrap/settings.py
@@ -43,6 +43,7 @@ class BaseServiceSettings(
         env_prefix=ENV_PREFIX,
         env_file_encoding="utf-8",
         populate_by_name=True,
+        extra="allow",
     )
 
 


### PR DESCRIPTION
I'm initiating settings by hand like this:
```python
                FastApiSettings(
                    service_debug=settings.platform.debug,
                    service_name=settings.app_title,
                    service_environment=settings.env.environment_name,
                    service_version=settings.env.version,
                    sentry_dsn=settings.sentry_dsn,
                    sentry_additional_params={"release": settings.env.version},
                    opentelemetry_service_name=settings.opentelemetry_service_name,
                    opentelemetry_endpoint=settings.platform.opentelemetry_endpoint,
                    opentelemetry_container_name=settings.app_title,
                    opentelemetry_namespace=settings.platform.product_name,
                    swagger_path=settings.doc_prefix,
                    health_checks_path=f"{settings.api_prefix}/health/",
                    logging_log_level=getLevelName(settings.platform.log_level.value.upper()),
                    logging_flush_level=getLevelName(settings.platform.logging_flush_level.upper()),
                )
```
And getting ValidationError for some keys, like they are extra and not allowed.
Seems like it's due to multiple inheritance.

Seems like using `extra="allow"` is fixing this problem