### PR TITLE
fix OTL exclude urls param parsing

### DIFF
--- a/microbootstrap/bootstrappers/fastapi.py
+++ b/microbootstrap/bootstrappers/fastapi.py
@@ -91,7 +91,7 @@ class FastApiOpentelemetryInstrument(OpentelemetryInstrument):
         FastAPIInstrumentor.instrument_app(
             application,
             tracer_provider=self.tracer_provider,
-            excluded_urls=self.instrument_config.opentelemetry_exclude_urls,
+            excluded_urls=",".join(self.instrument_config.opentelemetry_exclude_urls),
         )
         return application
 

--- a/microbootstrap/instruments/logging_instrument.py
+++ b/microbootstrap/instruments/logging_instrument.py
@@ -38,7 +38,7 @@ def fill_log_message(
     start_time: int,
 ) -> None:
     process_time: typing.Final = time.perf_counter_ns() - start_time
-    url_with_query: typing.Final = make_path_with_query_string(typing.cast(ScopeType, request.scope))
+    url_with_query: typing.Final = make_path_with_query_string(typing.cast("ScopeType", request.scope))
     client_host: typing.Final = request.client.host if request.client is not None else None
     client_port: typing.Final = request.client.port if request.client is not None else None
     http_method: typing.Final = request.method


### PR DESCRIPTION
As stated in OTL docs:

> excluded_urls: Optional comma delimited string of regexes to match URLs that should not be traced.
