### PR TITLE
opentelemetry: add auto instrumentation

### DIFF
--- a/microbootstrap/instruments/opentelemetry_instrument.py
+++ b/microbootstrap/instruments/opentelemetry_instrument.py
@@ -12,6 +12,7 @@ from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor
 from opentelemetry.trace import format_span_id, set_tracer_provider
+from opentelemetry.instrumentation import auto_instrumentation
 
 from microbootstrap.instruments.base import BaseInstrumentConfig, Instrument
 
@@ -86,6 +87,8 @@ class BaseOpentelemetryInstrument(Instrument[OpentelemetryConfigT]):
             instrumentor_with_params.instrumentor.uninstrument(**instrumentor_with_params.additional_params)
 
     def bootstrap(self) -> None:
+        auto_instrumentation.initialize()
+
         attributes = {
             resources.SERVICE_NAME: self.instrument_config.opentelemetry_service_name
             or self.instrument_config.service_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,17 @@ dependencies = [
     "sentry-sdk>=2.7",
     "structlog>=24",
     "pyroscope-io; platform_system != 'Windows'",
+    "opentelemetry-distro[otlp]>=0.54b1",
+    "opentelemetry-instrumentation-aio-pika>=0.54b1",
+    "opentelemetry-instrumentation-aiohttp-client>=0.54b1",
+    "opentelemetry-instrumentation-aiokafka>=0.54b1",
+    "opentelemetry-instrumentation-asyncpg>=0.54b1",
+    "opentelemetry-instrumentation-httpx>=0.54b1",
+    "opentelemetry-instrumentation-logging>=0.54b1",
+    "opentelemetry-instrumentation-redis>=0.54b1",
+    "opentelemetry-instrumentation-psycopg>=0.54b1",
+    "opentelemetry-instrumentation-sqlalchemy>=0.54b1",
+    "opentelemetry-instrumentation-asyncio>=0.54b1",
 ]
 dynamic = ["version"]
 authors = [{ name = "community-of-python" }]
@@ -68,7 +79,6 @@ dev = [
     "anyio>=4.8.0",
     "httpx>=0.28.1",
     "mypy>=1.14.1",
-    "opentelemetry-instrumentation-redis>=0.48b0",
     "pre-commit>=4.0.1",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",


### PR DESCRIPTION
- Enable auto initialize for instrumentation
- To enchance opentelemetry logs add a few instrumentation utilities.
- To be precise:
- RabbitMQ (aio-pika)
- aiohttp (client)
- aiokafka (kafka)
- asyncpg (postgres)
- psycopg (postgres)
- httpx
- logging (adds traces to logs)
- redis (move from dev to main deps)
- sqlalchemy
- asyncio (monitor async events)