### PR TITLE
instruments: open_telemetry: port auto_instrumentation

### DIFF
--- a/microbootstrap/instruments/opentelemetry_instrument.py
+++ b/microbootstrap/instruments/opentelemetry_instrument.py
@@ -5,8 +5,10 @@ import threading
 import typing
 
 import pydantic
+import structlog
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation import auto_instrumentation
+from opentelemetry.instrumentation.dependencies import DependencyConflictError
+from opentelemetry.instrumentation.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore[attr-defined] # noqa: TC002
 from opentelemetry.sdk import resources
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
@@ -14,8 +16,12 @@ from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.trace import format_span_id, set_tracer_provider
+from opentelemetry.util._importlib_metadata import entry_points
 
 from microbootstrap.instruments.base import BaseInstrumentConfig, Instrument
+
+
+LOGGER_OBJ: typing.Final = structlog.get_logger(__name__)
 
 
 try:
@@ -54,6 +60,12 @@ class OpentelemetryConfig(BaseInstrumentConfig):
     opentelemetry_insecure: bool = pydantic.Field(default=True)
     opentelemetry_instrumentors: list[OpenTelemetryInstrumentor] = pydantic.Field(default_factory=list)
     opentelemetry_exclude_urls: list[str] = pydantic.Field(default=["/metrics"])
+    opentelemetry_disabled_instrumentations: list[str] = pydantic.Field(
+        default=[
+            one_package_to_exclude.strip()
+            for one_package_to_exclude in os.environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, "").split(",")
+        ]
+    )
 
 
 @typing.runtime_checkable
@@ -80,6 +92,28 @@ class BaseOpentelemetryInstrument(Instrument[OpentelemetryConfigT]):
     instrument_name = "Opentelemetry"
     ready_condition = "Provide all necessary config parameters"
 
+    def _load_instrumentors(self) -> None:
+        for entry_point in entry_points(group="opentelemetry_instrumentor"):
+            if entry_point.name in self.instrument_config.opentelemetry_disabled_instrumentations:
+                LOGGER_OBJ.debug("Instrumentation skipped for library", entry_point_name=entry_point.name)
+                continue
+
+            try:
+                entry_point.load()().instrument(tracer_provider=self.tracer_provider)
+                LOGGER_OBJ.debug("Instrumented", entry_point_name=entry_point.name)
+            except DependencyConflictError as exc:
+                LOGGER_OBJ.debug("Skipping instrumentation", entry_point_name=entry_point.name, reason=exc.conflict)
+                continue
+            except ModuleNotFoundError as exc:
+                LOGGER_OBJ.debug("Skipping instrumentation", entry_point_name=entry_point.name, reason=exc.msg)
+                continue
+            except ImportError:
+                LOGGER_OBJ.debug("Importing failed, skipping it", entry_point_name=entry_point.name)
+                continue
+            except Exception:
+                LOGGER_OBJ.debug("Instrumenting failed", entry_point_name=entry_point.name)
+                raise
+
     def is_ready(self) -> bool:
         return bool(self.instrument_config.opentelemetry_endpoint) or self.instrument_config.service_debug
 
@@ -88,8 +122,6 @@ class BaseOpentelemetryInstrument(Instrument[OpentelemetryConfigT]):
             instrumentor_with_params.instrumentor.uninstrument(**instrumentor_with_params.additional_params)
 
     def bootstrap(self) -> None:
-        auto_instrumentation.initialize()
-
         attributes = {
             ResourceAttributes.SERVICE_NAME: self.instrument_config.opentelemetry_service_name
             or self.instrument_config.service_name,
@@ -122,6 +154,7 @@ class BaseOpentelemetryInstrument(Instrument[OpentelemetryConfigT]):
                 tracer_provider=self.tracer_provider,
                 **opentelemetry_instrumentor.additional_params,
             )
+        self._load_instrumentors()
         set_tracer_provider(self.tracer_provider)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,5 +130,5 @@ def reset_reloaded_settings_module() -> typing.Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def disable_auto_instrumentation(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(opentelemetry_instrument, "auto_instrumentation", MagicMock())
+def patch_out_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(opentelemetry_instrument, "entry_points", MagicMock(retrun_value=[]))

--- a/tests/instruments/test_pyroscope.py
+++ b/tests/instruments/test_pyroscope.py
@@ -50,7 +50,6 @@ class TestPyroscopeInstrument:
         async def test_handler() -> None: ...
 
         FastAPITestClient(app=fastapi_application).get("/test-handler")
-
         assert (
             add_thread_tag_mock.mock_calls
             == remove_thread_tag_mock.mock_calls


### PR DESCRIPTION
- auto_instrumentation.initialize() uses a distro for loading instrumentation. This overrides some needed defaults, that we use in our loader. E.g. it starts exporting telemetry somewhere undesirable. So these changes port the loader to our infrastructure.